### PR TITLE
actions: 의존성 파일 캐시에 등록

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -1,0 +1,25 @@
+name: Dependency Cache
+on: push
+jobs:
+  cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.yarn/cache |
+            node_modules
+
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn install

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -13,13 +13,25 @@ jobs:
           node-version: '18'
 
       - name: Cache dependencies
+        id: yarn-cache
         uses: actions/cache@v3
         with:
-          path: ~/.yarn/cache |
+          path: |
+            ~/.yarn/cache
             node_modules
-
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
       - name: Install dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install
+
+      - name: Save Yarn cache
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.yarn/cache
+            node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## 체크리스트

- [x] 기능 추가
- [ ] 기능 수정

## 설명
- 의존성 파일을 매번 github actions에서 설치하면 의미없는 시간을 사용해야 하므로 캐시에 등록해놓고 사용할 수 있도록 구축