### PR TITLE
fix: 페이지를 조회할 때 중복되는 페이지는 제거

### DIFF
--- a/src/game-builder/game/application/usecases/mapper/to-get-all-res.mapper.ts
+++ b/src/game-builder/game/application/usecases/mapper/to-get-all-res.mapper.ts
@@ -66,11 +66,16 @@ export const toGetAllResMapper = (
     });
   }
 
-  result.sort((a, b) => a.depth - b.depth);
+  // 중복되는 page 제거
+  const uniqueResult = result.filter((page, index, self) =>
+    index === self.findIndex((t) => t.id === page.id),
+  );
+  uniqueResult.sort((a, b) => a.depth - b.depth);
+
 
   return {
     id: game.id,
     title: game.title,
-    pages: result,
+    pages: uniqueResult,
   };
 };


### PR DESCRIPTION
## 체크리스트

- [ ] 기능 추가
- [x] 기능 수정

## 설명
- 게임을 조회할 때 페이지가 중복되어 출력되는 문제가 있어 중복을 제거함.